### PR TITLE
Corrects the bug occurring when SNPs are filtered in pcgc_r2.py

### DIFF
--- a/pcgc_r2.py
+++ b/pcgc_r2.py
@@ -80,7 +80,7 @@ def compute_r2_prod(args):
         raise ValueError(error_msg)
     t0 = time.time()
     geno_array._currentSNP = 0
-    r2prod_table = geno_array.ldScoreVarBlocks(block_left, args.chunk_size, annot=df_annotations.values)
+    r2prod_table = geno_array.ldScoreVarBlocks(block_left, args.chunk_size, annot=df_annotations.values.take(geno_array.kept_snps).reshape((len(geno_array.kept_snps), 1)))
     
     df_r2prod_table = pd.DataFrame(r2prod_table, index=df_annotations.columns, columns=df_annotations.columns)
     return df_r2prod_table


### PR DESCRIPTION
When some SNPs are filtered after loading the *.bed file the error "Incorrect number of SNPs in annot" occurs. It's due to the annot file which is not filtered to reflect the new SNP list. This commit corrects that by filtering the annot file used in ldScoreVarBlocks